### PR TITLE
update test_datatable_urls_doi to warn on ezEML `function = "download"`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # DPchecker 1.0.1 (under development)
 
+## 2025-04-01
+  * fix bug that caused `test_datatable_urls_doi` to produce unexpected errors when checking metadata generated from ezEML.
+
 ## 2025-03-25
   * fix bug that caused several functions to fail to detect certain .csv files
 

--- a/R/tabular_data_congruence.R
+++ b/R/tabular_data_congruence.R
@@ -431,6 +431,10 @@ test_datatable_urls_doi <-  function (metadata = load_metadata(directory)) {
         cli::cli_abort(c("x" = "One or more data files lack URLs. Could not test whether URLs are properly formatted or correspond to the corect DOI. Use {.fn EMLeditor::set_data_urls} to add them."))
         return(invisible(metadata))
       }
+      #handle <url function="download> tag from ezEML:
+      if (length(seq_along(url)) > 1) {
+        url <- url$url
+      }
       prefix <- stringr::str_sub(url, 1, stringr::str_length(url)-7)
       suffix <- stringr::str_sub(url, -7, -1)
 

--- a/R/tabular_data_congruence.R
+++ b/R/tabular_data_congruence.R
@@ -431,10 +431,15 @@ test_datatable_urls_doi <-  function (metadata = load_metadata(directory)) {
         cli::cli_abort(c("x" = "One or more data files lack URLs. Could not test whether URLs are properly formatted or correspond to the corect DOI. Use {.fn EMLeditor::set_data_urls} to add them."))
         return(invisible(metadata))
       }
+
       #handle <url function="download> tag from ezEML:
       if (length(seq_along(url)) > 1) {
-        url <- url$url
+        bad_url <- bad_url + 1
+        tbl_name <- data_tbl[[i]][["physical"]][["objectName"]]
+        cli::cli_warn(c("!" = "Metadata URL for the data table {.var {tbl_name}} is incorrectly formatted. Use {.fn EMLeditor::set_data_urls} to update the URLs."))
+        return(invisible(metadata))
       }
+
       prefix <- stringr::str_sub(url, 1, stringr::str_length(url)-7)
       suffix <- stringr::str_sub(url, -7, -1)
 


### PR DESCRIPTION
closes #167 